### PR TITLE
fix(cla): store signatures off master, where a bot can write them

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,7 +27,12 @@ jobs:
         with:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/imqueue/.github/blob/master/CONTRIBUTION-TERMS.md'
-          branch: 'master'
+          # NOT master, and not any branch that gains a ruleset later. The
+          # bot writes this file with a direct commit, which cannot satisfy the
+          # status check the default branch requires — every signature failed
+          # to record, so no outside contribution could be merged. The branch
+          # holds the signature file and nothing else.
+          branch: 'cla-signatures'
           allowlist: 'dependabot[bot],*[bot]'
           custom-notsigned-prcomment: >-
             Thank you for your contribution to **@imqueue**. Before this pull


### PR DESCRIPTION
CLA Assistant records a signature by committing `signatures/version1/cla.json` directly to the branch it is pointed at — no pull request, no checks. That branch was `master`, which a ruleset covers, so the write is rejected:

```
Error occurred when creating the signed contributors file: Repository rule violations found
. Make sure the branch where signatures are stored is NOT protected.
```

The consequence is not cosmetic: the signature is never stored, the `cla` check stays red for the contributor, and re-signing cannot help. No outside contribution can be merged.

Signatures now go to the unprotected `cla-signatures` branch — an orphan branch holding that one file plus a README saying why it sits off to the side, so nobody later "tidies it up" by protecting it. The existing `signatures/version1/cla.json` was copied to that branch **verbatim**, so recorded signatures carry over unchanged. The copy on `master` is left untouched as a historical record; the action no longer reads it.

**This PR's own `cla` check will still fail** — `pull_request_target` runs the workflow from the base branch, so it uses the old config. The fix applies from the first PR opened after this merges.

Same change as imqueue/redis-broker#2, rolled across every @imqueue repository with a CLA workflow and a protected default branch.
